### PR TITLE
change default values for yogi optimizer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -340,9 +340,10 @@ learning rate control, and has similar theoretical guarantees on convergence as 
     # model = ...
     optimizer = optim.Yogi(
         m.parameters(),
-        lr= 1e-3,
+        lr= 1e-2,
         betas=(0.9, 0.999),
-        eps=1e-8,
+        eps=1e-3,
+        initial_accumulator=1e-6,
         weight_decay=0,
     )
     optimizer.step()

--- a/torch_optimizer/yogi.py
+++ b/torch_optimizer/yogi.py
@@ -13,16 +13,16 @@ class Yogi(Optimizer):
     r"""Implements Yogi Optimizer Algorithm.
     It has been proposed in `Adaptive methods for Nonconvex Optimization`_.
     Arguments:
-        params (iterable): iterable of parameters to optimize or dicts defining
+        params: iterable of parameters to optimize or dicts defining
             parameter groups
-        lr (float, optional): learning rate (default: 1e-2)
-        betas (Tuple[float, float], optional): coefficients used for computing
+        lr: learning rate (default: 1e-2)
+        betas: coefficients used for computing
             running averages of gradient and its square (default: (0.9, 0.999))
-        eps (float, optional): term added to the denominator to improve
+        eps: term added to the denominator to improve
             numerical stability (default: 1e-8)
-        initial_accumulator (float, optional): initial values for first and
+        initial_accumulator: initial values for first and
             second moments (default: 1e-6)
-        weight_decay (float, optional): weight decay (L2 penalty) (default: 0)
+        weight_decay: weight decay (L2 penalty) (default: 0)
 
     Example:
         >>> import torch_optimizer as optim
@@ -95,7 +95,7 @@ class Yogi(Optimizer):
                                 p.data,
                                 memory_format=torch.preserve_format
                                 ),
-                            group["initial_accumulator"]
+                            group['initial_accumulator']
                         )
                     # Exponential moving average of squared gradient values
                     state['exp_avg_sq'] = nn.init.constant_(
@@ -103,7 +103,7 @@ class Yogi(Optimizer):
                                 p.data,
                                 memory_format=torch.preserve_format
                                 ),
-                            group["initial_accumulator"]
+                            group['initial_accumulator']
                         )
 
                 exp_avg, exp_avg_sq = state['exp_avg'], state['exp_avg_sq']

--- a/torch_optimizer/yogi.py
+++ b/torch_optimizer/yogi.py
@@ -1,5 +1,6 @@
 import math
 import torch
+import torch.nn as nn
 from torch.optim.optimizer import Optimizer
 
 from .types import Betas2, OptFloat, OptLossClosure, Params
@@ -9,37 +10,38 @@ __all__ = ('Yogi',)
 
 
 class Yogi(Optimizer):
-    r"""Implements Yogi optimization algorithm.
-
-    It has been proposed in `Adaptive Methods for Nonconvex Optimization`__.
-
+    r"""Implements Yogi Optimizer Algorithm.
+    It has been proposed in `Adaptive methods for Nonconvex Optimization`_.
     Arguments:
-        params: iterable of parameters to optimize or dicts defining
+        params (iterable): iterable of parameters to optimize or dicts defining
             parameter groups
-        lr: learning rate (default: 1e-3)
-        betas: coefficients used for computing
+        lr (float, optional): learning rate (default: 1e-2)
+        betas (Tuple[float, float], optional): coefficients used for computing
             running averages of gradient and its square (default: (0.9, 0.999))
-        eps: term added to the denominator to improve
+        eps (float, optional): term added to the denominator to improve
             numerical stability (default: 1e-8)
-        weight_decay: weight decay (L2 penalty) (default: 0)
+        initial_accumulator (float, optional): initial values for first and
+            second moments (default: 1e-6)
+        weight_decay (float, optional): weight decay (L2 penalty) (default: 0)
 
     Example:
         >>> import torch_optimizer as optim
-        >>> optimizer = optim.Yogi(model.parameters(), lr=0.1)
+        >>> optimizer = optim.Yogi(model.parameters(), lr=0.01, betas=(0.9, 0.999), 
+        		eps=1e-3, initial_accumulator=1e-6)
         >>> optimizer.zero_grad()
         >>> loss_fn(model(input), target).backward()
         >>> optimizer.step()
 
     __ https://papers.nips.cc/paper/8186-adaptive-methods-for-nonconvex-optimization  # noqa
     """
-
     def __init__(
         self,
         params: Params,
-        lr: float = 1e-3,
+        lr: float = 1e-2,
         betas: Betas2 = (0.9, 0.999),
         eps: float = 1e-3,
-        weight_decay: float = 0,
+        initial_accumulator: float = 1e-6,
+        weight_decay: float = 0
     ) -> None:
         if not 0.0 <= lr:
             raise ValueError(f'Invalid learning rate: {lr}')
@@ -52,7 +54,13 @@ class Yogi(Optimizer):
         if not 0.0 <= weight_decay:
             raise ValueError(f'Invalid weight_decay value: {weight_decay}')
 
-        defaults = dict(lr=lr, betas=betas, eps=eps, weight_decay=weight_decay)
+        defaults = dict(
+            lr=lr,
+            betas=betas,
+            eps=eps,
+            initial_accumulator=initial_accumulator,
+            weight_decay=weight_decay
+        )
         super(Yogi, self).__init__(params, defaults)
 
     def step(self, closure: OptLossClosure = None) -> OptFloat:
@@ -82,9 +90,21 @@ class Yogi(Optimizer):
                 if len(state) == 0:
                     state['step'] = 0
                     # Exponential moving average of gradient values
-                    state['exp_avg'] = torch.zeros_like(p)
+                    state['exp_avg'] = nn.init.constant_(
+                            torch.empty_like(
+                                p.data,
+                                memory_format=torch.preserve_format
+                                ),
+                            group["initial_accumulator"]
+                        )
                     # Exponential moving average of squared gradient values
-                    state['exp_avg_sq'] = torch.zeros_like(p)
+                    state['exp_avg_sq'] = nn.init.constant_(
+                            torch.empty_like(
+                                p.data,
+                                memory_format=torch.preserve_format
+                                ),
+                            group["initial_accumulator"]
+                        )
 
                 exp_avg, exp_avg_sq = state['exp_avg'], state['exp_avg_sq']
                 beta1, beta2 = group['betas']


### PR DESCRIPTION
Hi,
I have implemented yogi optimizer in pytorch and was able to reproduce results from the paper. Here is the repository for the experiments https://github.com/avinashsai/Adaptive-Nonconvex-Optimization/tree/master/PyTorch. This is the implementation according to the details mentioned in the paper.

In this repo, there are couple of changes to be made to coincide with the paper:
1. learning rate is 1e-2 and epsilon is 1e-3.
2. Unlike other optimizers yogi has non-zero initialization for first and second moments. 

I have made changes accordingly.