### PR TITLE
Add Rangers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 
 
-install_requires = ['torch>=1.1.0']
+install_requires = ['torch>=1.1.0', 'asranger>=0.0.5']
 
 PY35 = (3, 5, 0)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 
 
-install_requires = ['torch>=1.1.0', 'pytorch_ranger>=0.0.6']
+install_requires = ['torch>=1.1.0', 'pytorch_ranger>=0.1.0']
 
 PY35 = (3, 5, 0)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 
 
-install_requires = ['torch>=1.1.0', 'asranger>=0.0.5']
+install_requires = ['torch>=1.1.0', 'pytorch_ranger>=0.0.6']
 
 PY35 = (3, 5, 0)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 
 
-install_requires = ['torch>=1.1.0', 'pytorch_ranger>=0.1.0']
+install_requires = ['torch>=1.1.0', 'pytorch_ranger>=0.1.1']
 
 PY35 = (3, 5, 0)
 
@@ -56,6 +56,7 @@ keywords = [
     'radam',
     'sgdw',
     'yogi',
+    'ranger',
 ]
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -60,6 +60,9 @@ optimizers = [
     (optim.AccSGD, {'lr': 0.015}, 800),
     (build_lookahead, {'lr': 1.0}, 500),
     (optim.QHAdam, {'lr': 1.0}, 500),
+    (optim.Ranger, {'lr': .019, 'k': 3}, 2500),
+    (optim.RangerQH, {'lr': .25, 'k': 1}, 800),
+    (optim.RangerVA, {'lr': .25}, 800),
 ]
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -60,9 +60,6 @@ optimizers = [
     (optim.AccSGD, {'lr': 0.015}, 800),
     (build_lookahead, {'lr': 1.0}, 500),
     (optim.QHAdam, {'lr': 1.0}, 500),
-    (optim.Ranger, {'lr': .019, 'k': 3}, 2500),
-    (optim.RangerQH, {'lr': .25, 'k': 1}, 800),
-    (optim.RangerVA, {'lr': .25}, 800),
 ]
 
 

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -78,6 +78,9 @@ optimizers = [
     optim.SGDW,
     optim.Yogi,
     build_lookahead,
+    optim.Ranger,
+    optim.RangerQH,
+    optim.RangerVA
 ]
 
 

--- a/tests/test_optimizer_with_nn.py
+++ b/tests/test_optimizer_with_nn.py
@@ -64,6 +64,9 @@ optimizers = [
     (build_lookahead, {'lr': 0.1, 'weight_decay': 1e-3}, 200),
     (optim.QHM, {'lr': 0.1, 'weight_decay': 1e-5, 'momentum': 0.2}, 200),
     (optim.QHAdam, {'lr': 0.1, 'weight_decay': 1e-3}, 200),
+    (optim.Ranger, {'lr': .1, 'weight_decay': 1e-3}, 200),
+    (optim.RangerQH, {'lr': .01, 'weight_decay': 1e-3}, 200),
+    (optim.RangerVA, {'lr': .01, 'weight_decay': 1e-3}, 200),
 ]
 
 

--- a/torch_optimizer/__init__.py
+++ b/torch_optimizer/__init__.py
@@ -11,6 +11,7 @@ from .qhm import QHM
 from .radam import RAdam
 from .sgdw import SGDW
 from .yogi import Yogi
+from asranger import Ranger, RangerQH, RangerVA
 
 
 __all__ = (
@@ -27,5 +28,8 @@ __all__ = (
     'RAdam',
     'SGDW',
     'Yogi',
+    'Ranger',
+    'RangerQH',
+    'RangerVA'
 )
 __version__ = '0.0.1a11'

--- a/torch_optimizer/__init__.py
+++ b/torch_optimizer/__init__.py
@@ -11,7 +11,7 @@ from .qhm import QHM
 from .radam import RAdam
 from .sgdw import SGDW
 from .yogi import Yogi
-from asranger import Ranger, RangerQH, RangerVA
+from pytorch_ranger import Ranger, RangerQH, RangerVA
 
 
 __all__ = (


### PR DESCRIPTION
As discussed in #64, just added the three Rangers as a dependency. 

For now, the params can't be tested because the error messages are not the same. Also, I could not make the `beale` test work for `Ranger`.

This is just a draft, feel free to push to my fork if you want to change the PR.

Regarding the docstrings and types, I wonder if it wouldn't be easier to sublass the optimizers here so that we can use the object in `types.py`. 
Or should I copy them there? 