### PR TITLE
Add torch_optimizer.get() method

### DIFF
--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -1,0 +1,18 @@
+import torch
+import torch_optimizer as optim
+import pytest
+
+
+@pytest.mark.parametrize('name_optim_tuple', optim.NAME_OPTIM_MAP.items())
+def test_returns_optimizer_cls(name_optim_tuple):
+    optimizer_cls = optim.get(name_optim_tuple[0])
+    assert optimizer_cls == name_optim_tuple[1]
+    assert torch.optim.Optimizer in optimizer_cls.__bases__
+
+
+@pytest.mark.parametrize('should_raise', [
+    'not_an_optimizer_str', int(), torch.optim.Optimizer
+])
+def test_raises(should_raise):
+    with pytest.raises(ValueError):
+        optim.get(should_raise)

--- a/torch_optimizer/__init__.py
+++ b/torch_optimizer/__init__.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Callable, Type
+from typing import Optional, Type
 from .accsgd import AccSGD
 from .adabound import AdaBound
 from .adamod import AdaMod

--- a/torch_optimizer/__init__.py
+++ b/torch_optimizer/__init__.py
@@ -33,3 +33,29 @@ __all__ = (
     'RangerVA'
 )
 __version__ = '0.0.1a11'
+
+
+def get(identifier):
+    """ Returns an optimizer class from a string. Returns `identifier` if it
+    is already callable.
+
+    Args:
+        identifier (Union[str, Callable, None]): the optimizer identifier.
+
+    Returns:
+        torch.optim.Optimizer or None
+    """
+    if identifier is None:
+        return None
+    elif callable(identifier):
+        return identifier
+    elif isinstance(identifier, str):
+        cls = globals().get(identifier)
+        if cls is None:
+            raise ValueError('Could not interpret optimizer identifier: ' +
+                             str(identifier))
+        return cls
+    else:
+        raise ValueError('Could not interpret optimizer identifier: ' +
+                         str(identifier))
+

--- a/torch_optimizer/__init__.py
+++ b/torch_optimizer/__init__.py
@@ -1,3 +1,4 @@
+from typing import Optional, Union, Callable, Type
 from .accsgd import AccSGD
 from .adabound import AdaBound
 from .adamod import AdaMod
@@ -12,6 +13,7 @@ from .radam import RAdam
 from .sgdw import SGDW
 from .yogi import Yogi
 from pytorch_ranger import Ranger, RangerQH, RangerVA
+from torch import optim
 
 
 __all__ = (
@@ -35,27 +37,55 @@ __all__ = (
 __version__ = '0.0.1a11'
 
 
-def get(identifier):
-    """ Returns an optimizer class from a string. Returns `identifier` if it
-    is already callable.
+package_opts = [
+    AccSGD,
+    AdaBound,
+    AdaMod,
+    DiffGrad,
+    Lamb,
+    Lookahead,
+    NovoGrad,
+    PID,
+    QHAdam,
+    QHM,
+    RAdam,
+    SGDW,
+    Yogi,
+    Ranger,
+    RangerQH,
+    RangerVA,
+]
+
+builtin_opts = [
+    optim.Adadelta,
+    optim.Adagrad,
+    optim.Adam,
+    optim.AdamW,
+    optim.SparseAdam,
+    optim.Adamax,
+    optim.ASGD,
+    optim.SGD,
+    optim.Rprop,
+    optim.RMSprop,
+    optim.LBFGS
+]
+
+NAME_OPTIM_MAP = {
+    opt.__name__.lower(): opt for opt in package_opts + builtin_opts
+}
+
+
+def get(name: str,) -> Optional[Type[optim.Optimizer]]:
+    r"""Returns an optimizer class from its name. Case insensitive.
 
     Args:
-        identifier (Union[str, Callable, None]): the optimizer identifier.
-
-    Returns:
-        torch.optim.Optimizer or None
+        name: the optimizer name.
     """
-    if identifier is None:
-        return None
-    elif callable(identifier):
-        return identifier
-    elif isinstance(identifier, str):
-        cls = globals().get(identifier)
+    if isinstance(name, str):
+        cls = NAME_OPTIM_MAP.get(name.lower())
         if cls is None:
-            raise ValueError('Could not interpret optimizer identifier: ' +
-                             str(identifier))
+            raise ValueError('Could not interpret optimizer name: ' +
+                             str(name))
         return cls
-    else:
-        raise ValueError('Could not interpret optimizer identifier: ' +
-                         str(identifier))
-
+    raise ValueError('Could not interpret optimizer name: ' +
+                     str(name))


### PR DESCRIPTION
### The get method

How would you feel about a function like this? 

It makes it very easy to change between optimizer to test some of them, for example
```python
import argparse
import torch_optimizer as optim

parser = argparse.ArgumentParser()
parser.add_argument('--optimizer', default='AccSGD')
parser.add_argument('--lr', type=float, default=1e-3)

if __name__ == '__main__':
    args = parser.parse_args()
    opt_class = optim.get(args.optimizer)
    optimizer = opt_class(model.parameters(), lr=args.lr, **kwargs)
```

I can be improved and restricted as well. If it would be me, I'd make aliases, and probably search globals only for things in `__all__` and their aliases, and make the search case-insensitive. 

Tell me if you'd be interested. 

### Drop-in replacement for `torch.optim`

I would also import all optimizers from `torch.optim` directly, so that `Adam` could also be imported from here. 
If both these things are adopted, it would be easier than ever to compare between `Adam`, `Radam`, `SGD` and `AccSGD` for exampe. As simple as 
```bash
python train.py --optimizer adam
python train.py --optimizer radam
python train.py --optimizer sgd
python train.py --optimizer accsgd
```
With only one import (`torch_optimizer`) and no if statements.