### PR TITLE
Return type hint fixed for torch_optimizer.get

### DIFF
--- a/torch_optimizer/__init__.py
+++ b/torch_optimizer/__init__.py
@@ -66,7 +66,7 @@ _NAME_OPTIM_MAP = {
 }  # type: Dict[str, Type[Optimizer]]
 
 
-def get(name: str) -> Optional[Type[Optimizer]]:
+def get(name: str) -> Type[Optimizer]:
     r"""Returns an optimizer class from its name. Case insensitive.
 
     Args:

--- a/torch_optimizer/__init__.py
+++ b/torch_optimizer/__init__.py
@@ -1,4 +1,4 @@
-from typing import Optional, Type, List, Dict
+from typing import Type, List, Dict
 
 from pytorch_ranger import Ranger, RangerQH, RangerVA
 from torch.optim.optimizer import Optimizer


### PR DESCRIPTION
The `get` function no longer returns an `Optional` - this also fixes #100.