### PR TITLE
Fix flaky test

### DIFF
--- a/tests/test_optimizer_with_nn.py
+++ b/tests/test_optimizer_with_nn.py
@@ -60,7 +60,7 @@ optimizers = [
     (optim.AdaBound, {'lr': 1.5, 'gamma': 0.1, 'weight_decay': 1e-3}, 200),
     (optim.AdaMod, {'lr': 2.0, 'weight_decay': 1e-3}, 200),
     (optim.Adafactor, {'lr': None, 'weight_decay': 1e-3}, 200),
-    (optim.AdamP, {'lr': 1.0, 'weight_decay': 1e-3}, 200),
+    (optim.AdamP, {'lr': 0.045, 'weight_decay': 1e-3}, 800),
     (optim.AggMo, {'lr': 1.0, 'weight_decay': 1e-3}, 200),
     (optim.Apollo, {'lr': 0.1, 'weight_decay': 1e-3}, 200),
     (optim.DiffGrad, {'lr': 0.5, 'weight_decay': 1e-3}, 200),


### PR DESCRIPTION
Hi,

I ran the test `test_basic_nn_modeloptimizer_config` in `tests/test_optimizer_with_nn.py` by removing the seeds. I found that this test is flaky for many of the configs. For instance, for `AdamP` the test failed 73 out of 500 runs. I ran some experiment to find optimal hyper-parameter values which minimizes the flakiness. With `lr=0.045` and iterations=`800`, the test failure rate goes down to ~0%. 

Please let me know if this change looks fine. I am also looking into finding optimal values for other optimizers in this test. I can send them if you think this is reasonable.

Please let me know if you have any suggestions that I can incorporate.

Thanks!