### PR TITLE
Upgrade deprecated torch.svd() is deprecated in favor of torch.linalg.svd()

### DIFF
--- a/torch_optimizer/shampoo.py
+++ b/torch_optimizer/shampoo.py
@@ -8,7 +8,8 @@ def _matrix_power(matrix: torch.Tensor, power: float) -> torch.Tensor:
     # use CPU for svd for speed up
     device = matrix.device
     matrix = matrix.cpu()
-    u, s, v = torch.svd(matrix)
+    u, s, vh = torch.linalg.svd(matrix, full_matrices=False)
+    v = vh.mH
     return (u @ s.pow_(power).diag() @ v.t()).to(device)
 
 


### PR DESCRIPTION
Background:
[torch.svd()](https://pytorch.org/docs/stable/generated/torch.svd.html#torch.svd) is deprecated in favor of [torch.linalg.svd()](https://pytorch.org/docs/stable/generated/torch.linalg.svd.html#torch.linalg.svd) and will be removed in a future PyTorch release.

The previous implementation cause some issues like
```
RuntimeError: svd_cpu: the updating process of SBDSDC did not converge (error: 1)
```
which is fixed by Pytorch as pointed [here](https://github.com/pytorch/pytorch/issues/50095#:~:text=This%20is%20solved%20in%20master.%20When%20the%20algorithm%20does%20not%20converge%20now%20we%20fallback%20to%20an%20implementation%20that%20always%20converges.)